### PR TITLE
Ensure message input is encoded before it's hashed in ecdsa_verify

### DIFF
--- a/pypeerassets/kutil.py
+++ b/pypeerassets/kutil.py
@@ -110,4 +110,4 @@ class Kutil:
     def verify(self, message, signature):
         '''verify >message< against >signature<'''
 
-        return self.keypair.pubkey.ecdsa_verify(message, signature)
+        return self.keypair.pubkey.ecdsa_verify(message.encode('utf-8'), signature)


### PR DESCRIPTION
Prevents TypeError: Unicode-objects must be encoded before hashing
