### PR TITLE
Instance self reference and __init__ condition

### DIFF
--- a/pypeerassets/kutil.py
+++ b/pypeerassets/kutil.py
@@ -59,13 +59,13 @@ class Kutil:
         '''generate an address from pubkey'''
 
         if not compressed:
-            keyhash = unhexlify(mykey._pubkeyhash + hexlify(
-                new('ripemd160', sha256(mykey._pubkey).digest()).
+            keyhash = unhexlify(self._pubkeyhash + hexlify(
+                new('ripemd160', sha256(self._pubkey).digest()).
                 digest())
                                )
         else:
-            keyhash = unhexlify(mykey._pubkeyhash + hexlify(
-                new('ripemd160', sha256(mykey._pubkey_compressed + b'01').digest()).
+            keyhash = unhexlify(self._pubkeyhash + hexlify(
+                new('ripemd160', sha256(self._pubkey_compressed + b'01').digest()).
                 digest())
                                )
 

--- a/pypeerassets/kutil.py
+++ b/pypeerassets/kutil.py
@@ -24,7 +24,7 @@ class Kutil:
         if privkey is not None:
             self.keypair = PrivateKey(unhexlify(privkey))
 
-        if (privkey and wif and seed) is None:
+        if privkey == wif == seed == None:
             self.keypair = PrivateKey() # new keypair
 
         if network is None:


### PR DESCRIPTION
_Fix instance reference to self_:
Maintain consistency of instance reference.

_Fix logical if condition for no inputs:_
Kutil(privkey=....) was being overwritten due to this logical statement allowing 
for the creation of a new blank instance of PrivateKey()