### PR TITLE
Remove unneeded 01 byte

### DIFF
--- a/pypeerassets/kutil.py
+++ b/pypeerassets/kutil.py
@@ -65,7 +65,7 @@ class Kutil:
                                )
         else:
             keyhash = unhexlify(mykey._pubkeyhash + hexlify(
-                new('ripemd160', sha256(mykey._pubkey_compressed + b'01').digest()).
+                new('ripemd160', sha256(mykey._pubkey_compressed).digest()).
                 digest())
                                )
 

--- a/pypeerassets/networks.py
+++ b/pypeerassets/networks.py
@@ -15,6 +15,10 @@ networks = (
     Network("Peercoin", "ppc", "mainnet", b'37', b'b7', b'75', b'e6e8e9e5'),
     # Peercoin testnet
     Network("Peercoin", "tppc", "testnet", b'6f', b'ef', b'c4', b'cbf2c0ef')
+    # Bitcoin mainnet
+    Network("Bitcoin", "btc", "mainnet", b'00', b'80', b'05', b'd9b4bef9'),
+    # Bitcoin testnet
+    Network("Bitcoin", "tbtc", "testnet", b'6f', b'ef', b'c4', b'dab5bffa')
 )
 
 def query(query):


### PR DESCRIPTION
Tested and verified with 3 separate private keys and their corresponding compressed and uncompressed WIF and address outputs.

key = Kutil(privkey=...)

key.address()
key.address(compressed=True)

key.to_wif()
key.to_wif(compressed=True)

_ppcoind import test process_
First imported uncompressed wif output then validated against uncompressed address output resulting in **ismine: true**.

Next, imported compressed wif output then validated against compressed address output resulting in **ismine: true**.