### PR TITLE
Remove unneeded 01 byte

### DIFF
--- a/pypeerassets/kutil.py
+++ b/pypeerassets/kutil.py
@@ -65,7 +65,7 @@ class Kutil:
                                )
         else:
             keyhash = unhexlify(self._pubkeyhash + hexlify(
-                new('ripemd160', sha256(self._pubkey_compressed + b'01').digest()).
+                new('ripemd160', sha256(self._pubkey_compressed).digest()).
                 digest())
                                )
 


### PR DESCRIPTION
Tested and verified with 3 separate private keys and their corresponding compressed and uncompressed WIF and address outputs.

key = Kutil(privkey=...)

key.address()
key.address(compressed=True)

key.to_wif()
key.to_wif(compressed=True)

_ppcoind import test process_
First imported uncompressed wif output then validated against uncompressed address output resulting in **ismine: true.**

Next, imported compressed wif output then validated against compressed address output resulting in **ismine: true.**