### PR TITLE
Load network parameters

### DIFF
--- a/pypeerassets/kutil.py
+++ b/pypeerassets/kutil.py
@@ -34,6 +34,8 @@ class Kutil:
 
         if network:
             self.load_network_parameters(network)
+        else:
+            self.load_network_parameters('tppc') # Set to tppc if network parameter is not provided
 
         self._privkey = self.keypair.private_key
         self._pubkey = self.keypair.pubkey.serialize(compressed=False)


### PR DESCRIPTION
If no network parameter is passed to Kutil() then load ppc testnet parameters. 
Without this there will be an error returned due to wif not having a designated network prefix.