### PR TITLE
WIP - DONT MERGE Issue#70 validateaddress

### DIFF
--- a/pypeerassets/network/bitcoin.py
+++ b/pypeerassets/network/bitcoin.py
@@ -1,0 +1,57 @@
+from decimal import Decimal
+
+from pypeerassets.network.network import Network
+
+
+class Bitcoin(Network):
+
+    @property
+    def name(self):
+        return "bitcoin"
+
+    @property
+    def short_name(self):
+        return "btc"
+
+    @property
+    def pub_key_hash(self):
+        return b'00'
+
+    @property
+    def wif_prefix(self):
+        return b'80'
+
+    @property
+    def script_hash(self):
+        return b'05'
+
+    @property
+    def magic_bytes(self):
+        return b'd9b4bef9'
+
+    @property
+    def msg_prefix(self):
+        return b'\x18Bitcoin Signed Message:\n'
+
+    @property
+    def min_tx_fee(self):
+        return 0
+
+    @property
+    def min_vout_value(self):
+        return 0
+
+    @property
+    def tx_timestamp(self):
+        return False
+
+    @property
+    def denomination(self):
+        return Decimal('1e8')
+
+    @property
+    def is_testnet(self):
+        return False
+
+    def is_valid_address(self, address):
+        raise NotImplementedError

--- a/pypeerassets/network/bitcoin_testnet.py
+++ b/pypeerassets/network/bitcoin_testnet.py
@@ -1,0 +1,57 @@
+from decimal import Decimal
+
+from pypeerassets.network.network import Network
+
+
+class BitcoinTestnet(Network):
+
+    @property
+    def name(self):
+        return "bitcoin-testnet"
+
+    @property
+    def short_name(self):
+        return "tbtc"
+
+    @property
+    def pub_key_hash(self):
+        return b'6f'
+
+    @property
+    def wif_prefix(self):
+        return b'ef'
+
+    @property
+    def script_hash(self):
+        return b'c4'
+
+    @property
+    def magic_bytes(self):
+        return b'dab5bffa'
+
+    @property
+    def msg_prefix(self):
+        return b'\x18Bitcoin Signed Message:\n'
+
+    @property
+    def min_tx_fee(self):
+        return 0
+
+    @property
+    def min_vout_value(self):
+        return 0
+
+    @property
+    def tx_timestamp(self):
+        return False
+
+    @property
+    def denomination(self):
+        return Decimal('1e8')
+
+    @property
+    def is_testnet(self):
+        return True
+
+    def is_valid_address(self, address):
+        raise NotImplementedError

--- a/pypeerassets/network/network.py
+++ b/pypeerassets/network/network.py
@@ -1,0 +1,68 @@
+from abc import ABC, abstractmethod
+
+
+class Network(ABC):
+
+    @property
+    @abstractmethod
+    def name(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def short_name(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def pub_key_hash(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def wif_prefix(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def script_hash(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def magic_bytes(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def msg_prefix(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def min_tx_fee(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def min_vout_value(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def tx_timestamp(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def denomination(self):
+        raise NotImplementedError
+
+    @property
+    @abstractmethod
+    def is_testnet(self):
+        raise NotImplementedError
+
+    @abstractmethod
+    def is_valid_address(self, address):
+        raise NotImplementedError

--- a/pypeerassets/network/peercoin.py
+++ b/pypeerassets/network/peercoin.py
@@ -1,0 +1,57 @@
+from decimal import Decimal
+
+from pypeerassets.network.network import Network
+
+
+class Peercoin(Network):
+
+    @property
+    def name(self):
+        return "peercoin"
+
+    @property
+    def short_name(self):
+        return "ppc"
+
+    @property
+    def pub_key_hash(self):
+        return b'37'
+
+    @property
+    def wif_prefix(self):
+        return b'b7'
+
+    @property
+    def script_hash(self):
+        return b'75'
+
+    @property
+    def magic_bytes(self):
+        return b'e6e8e9e5'
+
+    @property
+    def msg_prefix(self):
+        return b'\x17PPCoin Signed Message:\n'
+
+    @property
+    def min_tx_fee(self):
+        return Decimal(0.01)
+
+    @property
+    def min_vout_value(self):
+        return 0
+
+    @property
+    def tx_timestamp(self):
+        return True
+
+    @property
+    def denomination(self):
+        return Decimal('1e6')
+
+    @property
+    def is_testnet(self):
+        return False
+
+    def is_valid_address(self, address):
+        raise NotImplementedError

--- a/pypeerassets/network/peercoin.py
+++ b/pypeerassets/network/peercoin.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+from btcpy.structs.address import Address
+
 from pypeerassets.network.network import Network
 
 
@@ -54,4 +56,4 @@ class Peercoin(Network):
         return False
 
     def is_valid_address(self, address):
-        raise NotImplementedError
+        return Address.is_valid(address)

--- a/pypeerassets/network/peercoin_testnet.py
+++ b/pypeerassets/network/peercoin_testnet.py
@@ -1,0 +1,57 @@
+from decimal import Decimal
+
+from pypeerassets.network.network import Network
+
+
+class PeercoinTestnet(Network):
+
+    @property
+    def name(self):
+        return "peercoin-testnet"
+
+    @property
+    def short_name(self):
+        return "tppc"
+
+    @property
+    def pub_key_hash(self):
+        return b'6f'
+
+    @property
+    def wif_prefix(self):
+        return b'ef'
+
+    @property
+    def script_hash(self):
+        return b'c4'
+
+    @property
+    def magic_bytes(self):
+        return b'cbf2c0ef'
+
+    @property
+    def msg_prefix(self):
+        return b'\x17PPCoin Signed Message:\n'
+
+    @property
+    def min_tx_fee(self):
+        return Decimal(0.01)
+
+    @property
+    def min_vout_value(self):
+        return 0
+
+    @property
+    def tx_timestamp(self):
+        return True
+
+    @property
+    def denomination(self):
+        return Decimal('1e6')
+
+    @property
+    def is_testnet(self):
+        return True
+
+    def is_valid_address(self, address):
+        raise NotImplementedError

--- a/pypeerassets/network/peercoin_testnet.py
+++ b/pypeerassets/network/peercoin_testnet.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+from btcpy.structs.address import Address
+
 from pypeerassets.network.network import Network
 
 
@@ -54,4 +56,4 @@ class PeercoinTestnet(Network):
         return True
 
     def is_valid_address(self, address):
-        raise NotImplementedError
+        return Address.is_valid(address)

--- a/pypeerassets/networks.py
+++ b/pypeerassets/networks.py
@@ -1,49 +1,12 @@
-from collections import namedtuple
-from decimal import Decimal
+from pypeerassets.network.bitcoin import Bitcoin
+from pypeerassets.network.bitcoin_testnet import BitcoinTestnet
+from pypeerassets.network.peercoin import Peercoin
+from pypeerassets.network.peercoin_testnet import PeercoinTestnet
 
 
-NetworkParams = namedtuple('NetworkParams', [
-    'network_name',
-    'network_shortname',
-    'pubkeyhash',
-    'wif_prefix',
-    'scripthash',
-    'magicbytes',
-    'msgPrefix',
-    'min_tx_fee',
-    'min_vout_value',
-    'tx_timestamp',
-    'denomination',
-])
-
-
-'''
-Network name should be lowercase, for testnet append "-testnet".
-For abbreviation prefix testnet of the network with "t".
-'''
-
-networks = (
-    # Peercoin mainnet
-    NetworkParams("peercoin", "ppc", b'37', b'b7', b'75', b'e6e8e9e5',
-                  b'\x17PPCoin Signed Message:\n', Decimal(0.01),
-                  0, True, Decimal('1e6')),
-    # Peercoin testnet
-    NetworkParams("peercoin-testnet", "tppc", b'6f', b'ef', b'c4', b'cbf2c0ef',
-                  b'\x17PPCoin Signed Message:\n', Decimal(0.01),
-                  0, True, Decimal('1e6')),
-    # Bitcoin mainnet
-    NetworkParams("bitcoin", "btc", b'00', b'80', b'05', b'd9b4bef9',
-                  b'\x18Bitcoin Signed Message:\n', 0, 0, False, Decimal('1e8')),
-    # Bitcoin testnet
-    NetworkParams("bitcoin-testnet", "tbtc", b'6f', b'ef', b'c4', b'dab5bffa',
-                  b'\x18Bitcoin Signed Message:\n', 0, 0, False, Decimal('1e8'))
-)
-
-
-def net_query(query):
-    '''find matching parameter among the networks'''
-
-    for network in networks:
-        for field in network:
-            if field == query:
-                return network
+NETWORKS = {
+    "bitcoin": Bitcoin,
+    "bitcoin-testnet": BitcoinTestnet,
+    "peercoin": Peercoin,
+    "peercoin-testnet": PeercoinTestnet,
+}

--- a/pypeerassets/provider/common.py
+++ b/pypeerassets/provider/common.py
@@ -1,34 +1,21 @@
 '''Common provider class with basic features.'''
 
 from abc import ABC, abstractmethod
-from pypeerassets.exceptions import UnsupportedNetwork
-from pypeerassets.pa_constants import PAParams, param_query
-from pypeerassets.networks import NetworkParams, net_query
 from decimal import Decimal
 import urllib.request
+
+from pypeerassets.exceptions import UnsupportedNetwork
+from pypeerassets.network.network import Network
+from pypeerassets.pa_constants import PAParams, param_query
 
 
 class Provider(ABC):
 
-    @staticmethod
-    def _netname(name: str) -> dict:
-        '''resolute network name,
-        required because some providers use shortnames and other use longnames.'''
+    @abstractmethod
+    def __init__(self, network: Network):
+        '''Initialize a Provider.'''
 
-        try:
-            long = net_query(name).network_name
-            short = net_query(name).network_shortname
-        except AttributeError:
-            raise UnsupportedNetwork('''This blockchain network is not supported by the pypeerassets, check networks.py for list of supported networks.''')
-
-        return {'long': long,
-                'short': short}
-
-    @property
-    def network(self) -> str:
-        '''return network full name'''
-
-        return self._netname(self.net)['long']
+        self._network = network
 
     @property
     def pa_parameters(self) -> PAParams:
@@ -37,19 +24,11 @@ class Provider(ABC):
         return param_query(self.network)
 
     @property
-    def network_properties(self) -> NetworkParams:
-        '''network parameters [min_fee, denomination, ...]'''
+    @abstractmethod
+    def network(self) -> Network:
+        '''Return the Network object the Provider is using.'''
 
-        return net_query(self.network)
-
-    @property
-    def is_testnet(self) -> bool:
-        """testnet or not?"""
-
-        if "testnet" in self.network:
-            return True
-        else:
-            return False
+        return self._network
 
     @classmethod
     def sendrawtransaction(cls, rawtxn: str) -> dict:

--- a/pypeerassets/provider/explorer.py
+++ b/pypeerassets/provider/explorer.py
@@ -5,6 +5,7 @@ from urllib.request import urlopen
 from btcpy.structs.transaction import ScriptSig, Sequence, TxIn
 
 from pypeerassets.exceptions import InsufficientFunds, UnsupportedNetwork
+from pypeerassets.network.network import Network
 from pypeerassets.provider.common import Provider
 
 
@@ -12,20 +13,20 @@ class Explorer(Provider):
 
     '''API wrapper for https://explorer.peercoin.net blockexplorer.'''
 
-    def __init__(self, network: str) -> None:
-        """
-        : network = peercoin [ppc], peercoin-testnet [tppc] ...
-        """
-
-        self.net = self._netname(network)['short']
-        if 'ppc' not in self.net:
+    def __init__(self, network: Network) -> None:
+        super().__init__(network)
+        if self.network.name not in ("peercoin", "peercoin-testnet",):
             raise UnsupportedNetwork('This API only supports Peercoin.')
-            getcontext().prec = 6  # set to six decimals if it's Peercoin
+        getcontext().prec = 6  # set to six decimals if it's Peercoin
+
+    @property
+    def network(self) -> Network:
+        return super().network
 
     def api_fetch(self, command):
 
         apiurl = 'https://explorer.peercoin.net/api/'
-        if self.is_testnet:
+        if self.network.is_testnet:
             apiurl = 'https://testnet-explorer.peercoin.net/api/'
 
         response = urlopen(apiurl + command)
@@ -40,7 +41,7 @@ class Explorer(Provider):
     def ext_fetch(self, command):
 
         extapiurl = 'https://explorer.peercoin.net/ext/'
-        if self.is_testnet:
+        if self.network.is_testnet:
             extapiurl = 'https://testnet-explorer.peercoin.net/ext/'
 
         response = urlopen(extapiurl + command)

--- a/pypeerassets/provider/holytransaction.py
+++ b/pypeerassets/provider/holytransaction.py
@@ -1,36 +1,40 @@
-
-'''
-API wrapper for holytransaction blockexplorer.
-See https://peercoin.holytransaction.com/info for more information.
-'''
+from decimal import Decimal
 
 import requests
-from decimal import Decimal
-from .common import Provider
+
+from pypeerassets.network.network import Network
+from pypeerassets.provider.common import Provider
 
 
 class Holy(Provider):
 
-    """API wrapper for holytransaction.com blockexplorer,
-    it only implements queries relevant to peerassets.
-    Please note that holytransactions will only provide last 100k indexed
-    transactions for each address.
+    """API wrapper for holytransaction.com blockexplorer, it only implements
+    queries relevant to peerassets. Please note that holytransactions will only
+    provide last 100k indexed transactions for each address.
+    See https://peercoin.holytransaction.com/info for more information.
     """
 
-    def __init__(self, network: str):
-        """
-        : network = ppc, peercoin-testnet ...
-        """
+    api_methods = (
+        "getblock",
+        "getblockcount",
+        "getblockhash",
+        "getdifficulty",
+        "getrawtransaction",
+    )
+    ext_api_methods = (
+        "getaddress",
+        "getbalance",
+    )
 
-        self.net = self._netname(network)['long']
-        self.api = "https://{network}.holytransaction.com/api/".format(
-                   network=self._netname(network)['long'])
-        self.ext_api = "https://{network}.holytransaction.com/ext/".format(
-                       network=self._netname(network)['long'])
-        self.api_methods = ("getdifficulty", "getrawtransaction",
-                           "getblockcount", "getblockhash", "getblock")
-        self.ext_api_methods = ("getaddress", "getbalance")
+    def __init__(self, network: Network) -> None:
+        super().__init__(network)
+        self.api = "https://{network}.holytransaction.com/api/".format(network=self.network.name)
+        self.ext_api = "https://{network}.holytransaction.com/ext/".format(network=self.network.name)
         self.api_session = requests.Session()
+
+    @property
+    def network(self) -> Network:
+        return super().network
 
     def req(self, query: str, params: dict):
         """Send request, return response."""

--- a/pypeerassets/provider/mintr.py
+++ b/pypeerassets/provider/mintr.py
@@ -2,6 +2,7 @@ import json
 from urllib.request import Request, urlopen
 
 from pypeerassets.exceptions import UnsupportedNetwork
+from pypeerassets.network.network import Network
 from pypeerassets.provider.common import Provider
 
 
@@ -12,11 +13,14 @@ class Mintr(Provider):
     output to match original RPC response.
     '''
 
-    def __init__(self, network="peercoin"):
-
-        self.net = self._netname(network)['long']
-        if self.net != "peercoin":
+    def __init__(self, network: Network) -> None:
+        super().__init__(network)
+        if self.network.name != "peercoin":
             raise UnsupportedNetwork("Mintr only supports the peercoin mainnet.")
+
+    @property
+    def network(self) -> Network:
+        return super().network
 
     def get(self, query):
 

--- a/pypeerassets/transactions.py
+++ b/pypeerassets/transactions.py
@@ -1,15 +1,31 @@
 
 '''transaction assembly/dissasembly'''
 
-from time import time
-from math import ceil
 from decimal import Decimal, getcontext
-getcontext().prec = 6
+from math import ceil
+from time import time
+
 from btcpy.structs.address import Address
-from btcpy.structs.transaction import TxOut, TxIn, Sequence, Locktime, Transaction, MutableTransaction
-from btcpy.structs.script import StackData, ScriptSig, NulldataScript, ScriptSig, ScriptPubKey
-from btcpy.structs.script import P2pkhScript, MultisigScript, P2shScript
-from .networks import net_query
+from btcpy.structs.script import (
+    MultisigScript,
+    NulldataScript,
+    P2pkhScript,
+    P2shScript,
+    StackData,
+    ScriptSig,
+    ScriptPubKey,
+)
+from btcpy.structs.transaction import (
+    Locktime,
+    MutableTransaction,
+    Sequence,
+    Transaction,
+    TxIn,
+    TxOut,
+)
+
+
+getcontext().prec = 6
 
 
 def calculate_tx_fee(tx_size: int) -> Decimal:

--- a/test/test_network_bitcoin.py
+++ b/test/test_network_bitcoin.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+import pytest
+
 from pypeerassets.network.bitcoin import Bitcoin
 
 
@@ -18,3 +20,11 @@ def test_network_parameters():
     assert bitcoin.tx_timestamp == False
     assert bitcoin.denomination == Decimal('1e8')
     assert bitcoin.is_testnet == False
+
+def test_is_valid_address():
+    """Check that the network can recognize valid addresses. NOTE: it's not
+    currenlty implemented :(
+    """
+    bitcoin = Bitcoin()
+    with pytest.raises(NotImplementedError):
+        bitcoin.is_valid_address("1BFQfjM29kubskmaAsPjPCfHYphYvKA7Pj")

--- a/test/test_network_bitcoin.py
+++ b/test/test_network_bitcoin.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+from pypeerassets.network.bitcoin import Bitcoin
+
+
+def test_network_parameters():
+    "Check that the network parameters are set properly."
+    bitcoin = Bitcoin()
+    assert bitcoin.name == "bitcoin"
+    assert bitcoin.short_name == "btc"
+    assert bitcoin.pub_key_hash == b'00'
+    assert bitcoin.wif_prefix == b'80'
+    assert bitcoin.script_hash == b'05'
+    assert bitcoin.magic_bytes == b'd9b4bef9'
+    assert bitcoin.msg_prefix == b'\x18Bitcoin Signed Message:\n'
+    assert bitcoin.min_tx_fee == 0
+    assert bitcoin.min_vout_value == 0
+    assert bitcoin.tx_timestamp == False
+    assert bitcoin.denomination == Decimal('1e8')
+    assert bitcoin.is_testnet == False

--- a/test/test_network_bitcoin_testnet.py
+++ b/test/test_network_bitcoin_testnet.py
@@ -1,5 +1,7 @@
 from decimal import Decimal
 
+import pytest
+
 from pypeerassets.network.bitcoin_testnet import BitcoinTestnet
 
 
@@ -18,3 +20,11 @@ def test_network_parameters():
     assert bitcoin_testnet.tx_timestamp == False
     assert bitcoin_testnet.denomination == Decimal('1e8')
     assert bitcoin_testnet.is_testnet == True
+
+def test_is_valid_address():
+    """Check that the network can recognize valid addresses. NOTE: it's not
+    currenlty implemented :(
+    """
+    bitcoin_testnet = BitcoinTestnet()
+    with pytest.raises(NotImplementedError):
+        bitcoin_testnet.is_valid_address("2NFNPUYRpDXf3YXEuVT6AdMesX4kyeyDjtp")

--- a/test/test_network_bitcoin_testnet.py
+++ b/test/test_network_bitcoin_testnet.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+from pypeerassets.network.bitcoin_testnet import BitcoinTestnet
+
+
+def test_network_parameters():
+    "Check that the network parameters are set properly."
+    bitcoin_testnet = BitcoinTestnet()
+    assert bitcoin_testnet.name == "bitcoin-testnet"
+    assert bitcoin_testnet.short_name == "tbtc"
+    assert bitcoin_testnet.pub_key_hash == b'6f'
+    assert bitcoin_testnet.wif_prefix == b'ef'
+    assert bitcoin_testnet.script_hash == b'c4'
+    assert bitcoin_testnet.magic_bytes == b'dab5bffa'
+    assert bitcoin_testnet.msg_prefix == b'\x18Bitcoin Signed Message:\n'
+    assert bitcoin_testnet.min_tx_fee == 0
+    assert bitcoin_testnet.min_vout_value == 0
+    assert bitcoin_testnet.tx_timestamp == False
+    assert bitcoin_testnet.denomination == Decimal('1e8')
+    assert bitcoin_testnet.is_testnet == True

--- a/test/test_network_peercoin.py
+++ b/test/test_network_peercoin.py
@@ -18,3 +18,13 @@ def test_network_parameters():
     assert peercoin.tx_timestamp == True
     assert peercoin.denomination == Decimal('1e6')
     assert peercoin.is_testnet == False
+
+def test_is_valid_address():
+    "Check that the network can recognize valid addresses."
+    peercoin = Peercoin()
+    assert peercoin.is_valid_address("PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw") is True
+    assert peercoin.is_valid_address("p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK") is True
+
+    assert peercoin.is_valid_address("1BFQfjM29kubskmaAsPjPCfHYphYvKA7Pj") is False
+    assert peercoin.is_valid_address("2NFNPUYRpDXf3YXEuVT6AdMesX4kyeyDjtp") is False
+    assert peercoin.is_valid_address("mj46gUeZgeD9ufU7Fvz2dWqaX6Nswtbpba") is False

--- a/test/test_network_peercoin.py
+++ b/test/test_network_peercoin.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+from pypeerassets.network.peercoin import Peercoin
+
+
+def test_network_parameters():
+    "Check that the network parameters are set properly."
+    peercoin = Peercoin()
+    assert peercoin.name == "peercoin"
+    assert peercoin.short_name == "ppc"
+    assert peercoin.pub_key_hash == b'37'
+    assert peercoin.wif_prefix == b'b7'
+    assert peercoin.script_hash == b'75'
+    assert peercoin.magic_bytes == b'e6e8e9e5'
+    assert peercoin.msg_prefix == b'\x17PPCoin Signed Message:\n'
+    assert peercoin.min_tx_fee == Decimal(0.01)
+    assert peercoin.min_vout_value == 0
+    assert peercoin.tx_timestamp == True
+    assert peercoin.denomination == Decimal('1e6')
+    assert peercoin.is_testnet == False

--- a/test/test_network_peercoin_testnet.py
+++ b/test/test_network_peercoin_testnet.py
@@ -18,3 +18,13 @@ def test_network_parameters():
     assert peercoin_testnet.tx_timestamp == True
     assert peercoin_testnet.denomination == Decimal('1e6')
     assert peercoin_testnet.is_testnet == True
+
+def test_is_valid_address():
+    "Check that the network can recognize valid addresses."
+    peercoin_testnet = PeercoinTestnet()
+    assert peercoin_testnet.is_valid_address("mj46gUeZgeD9ufU7Fvz2dWqaX6Nswtbpba") is True
+
+    assert peercoin_testnet.is_valid_address("PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw") is False
+    assert peercoin_testnet.is_valid_address("p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK") is False
+    assert peercoin_testnet.is_valid_address("1BFQfjM29kubskmaAsPjPCfHYphYvKA7Pj") is False
+    assert peercoin_testnet.is_valid_address("2NFNPUYRpDXf3YXEuVT6AdMesX4kyeyDjtp") is False

--- a/test/test_network_peercoin_testnet.py
+++ b/test/test_network_peercoin_testnet.py
@@ -1,0 +1,20 @@
+from decimal import Decimal
+
+from pypeerassets.network.peercoin_testnet import PeercoinTestnet
+
+
+def test_network_parameters():
+    "Check that the network parameters are set properly."
+    peercoin_testnet = PeercoinTestnet()
+    assert peercoin_testnet.name == "peercoin-testnet"
+    assert peercoin_testnet.short_name == "tppc"
+    assert peercoin_testnet.pub_key_hash == b'6f'
+    assert peercoin_testnet.wif_prefix == b'ef'
+    assert peercoin_testnet.script_hash == b'c4'
+    assert peercoin_testnet.magic_bytes == b'cbf2c0ef'
+    assert peercoin_testnet.msg_prefix == b'\x17PPCoin Signed Message:\n'
+    assert peercoin_testnet.min_tx_fee == Decimal(0.01)
+    assert peercoin_testnet.min_vout_value == 0
+    assert peercoin_testnet.tx_timestamp == True
+    assert peercoin_testnet.denomination == Decimal('1e6')
+    assert peercoin_testnet.is_testnet == True

--- a/test/test_provider_cryptoid.py
+++ b/test/test_provider_cryptoid.py
@@ -1,67 +1,68 @@
 from decimal import Decimal
 
+from pypeerassets.networks import NETWORKS
 from pypeerassets.provider.cryptoid import Cryptoid
 
 
 def test_cryptoid_is_testnet():
 
-    cryptoid = Cryptoid(network="ppc")
+    cryptoid = Cryptoid(NETWORKS["peercoin"]())
 
-    assert isinstance(cryptoid.is_testnet, bool)
-    assert cryptoid.is_testnet is False
+    assert isinstance(cryptoid.network.is_testnet, bool)
+    assert cryptoid.network.is_testnet is False
 
 
 def test_crypotid_network():
 
-    assert Cryptoid(network="ppc").network == "peercoin"
+    assert Cryptoid(NETWORKS["peercoin"]()).network.name == "peercoin"
 
 
 def test_cryptoid_getblockcount():
 
-    assert isinstance(Cryptoid(network="ppc").getblockcount(), int)
+    assert isinstance(Cryptoid(NETWORKS["peercoin"]()).getblockcount(), int)
 
 
 def test_cryptoid_getblock():
 
-    provider = Cryptoid(network="tppc")
+    provider = Cryptoid(NETWORKS["peercoin-testnet"]())
     assert isinstance(provider.getblock('0000000429a1e623da44a7430b9d9ae377bc2da203043c444c313b2d4390eba2'), dict)
 
 
 def test_cryptoid_get_block_hash():
 
-    assert isinstance(Cryptoid(network="ppc").getblockhash(3378), str)
+    assert isinstance(Cryptoid(NETWORKS["peercoin"]()).getblockhash(3378), str)
 
 
 def test_cryptoid_getdifficulty():
 
-    assert isinstance(Cryptoid(network="ppc").getdifficulty(), float)
+    assert isinstance(Cryptoid(NETWORKS["peercoin"]()).getdifficulty(), float)
 
 
 def test_cryptoid_getbalance():
 
-    assert isinstance(Cryptoid(network="ppc").getbalance(
+    assert isinstance(Cryptoid(NETWORKS["peercoin"]()).getbalance(
                       'PHvDhfz1dGyPbZZ3Qnp56y92zmy98sncZT'), Decimal)
 
 
 def test_cryptoid_getreceivedbyaddress():
 
-    assert isinstance(Cryptoid(network="ppc").getreceivedbyaddress(
+    assert isinstance(Cryptoid(NETWORKS["peercoin"]()).getreceivedbyaddress(
                       'PHvDhfz1dGyPbZZ3Qnp56y92zmy98sncZT'), Decimal)
 
 
 def test_cryptoid_listunspent():
 
-    assert isinstance(Cryptoid(network="ppc").listunspent(
+    assert isinstance(Cryptoid(NETWORKS["peercoin"]()).listunspent(
                       'PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw'), list)
 
 
 def test_cryptoid_getrawtransaction():
 
-    assert isinstance(Cryptoid(network="ppc").getrawtransaction(
+    assert isinstance(Cryptoid(NETWORKS["peercoin"]()).getrawtransaction(
                       '34d19bf5a5c757d5bcbf83a91ad9bc04365c58a035a6bf728bce8013ad04c173'), dict)
 
 
 def test_cryptoid_listtransactions():
 
-    assert isinstance(Cryptoid(network="tppc").listtransactions(
+    assert isinstance(Cryptoid(NETWORKS["peercoin-testnet"]()).listtransactions(
                       'msPLoMcHpn6Y28pPKwATG411m5X7Vodu3m'), list)

--- a/test/test_provider_explorer.py
+++ b/test/test_provider_explorer.py
@@ -1,67 +1,68 @@
 from decimal import Decimal
 
+from pypeerassets.networks import NETWORKS
 from pypeerassets.provider.explorer import Explorer
 
 
 def test_explorer_is_testnet():
 
-    explorer = Explorer(network="ppc")
+    explorer = Explorer(NETWORKS["peercoin"]())
 
-    assert isinstance(explorer.is_testnet, bool)
-    assert explorer.is_testnet is False
+    assert isinstance(explorer.network.is_testnet, bool)
+    assert explorer.network.is_testnet is False
 
 
 def test_explorer_network():
 
-    assert Explorer(network="ppc").network == "peercoin"
+    assert Explorer(NETWORKS["peercoin"]()).network.name == "peercoin"
 
 
 def test_explorer_getblockcount():
 
-    assert isinstance(Explorer(network="ppc").getblockcount(), int)
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).getblockcount(), int)
 
 
 def test_explorer_getblock():
 
-    provider = Explorer(network="ppc")
+    provider = Explorer(NETWORKS["peercoin"]())
     assert isinstance(provider.getblock('00000000000da9a26b4f4ce3f1f286438ec2198e5f60d108fafa700061b486e7'), dict)
 
 
 def test_explorer_get_block_hash():
 
-    assert isinstance(Explorer(network="ppc").getblockhash(3378), str)
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).getblockhash(3378), str)
 
 
 def test_explorer_getdifficulty():
 
-    assert isinstance(Explorer(network="ppc").getdifficulty(), dict)
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).getdifficulty(), dict)
 
 
 def test_explorer_getbalance():
 
-    assert isinstance(Explorer(network="ppc").getbalance(
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).getbalance(
                       'PHvDhfz1dGyPbZZ3Qnp56y92zmy98sncZT'), Decimal)
 
 
 def test_explorer_getreceivedbyaddress():
 
-    assert isinstance(Explorer(network="ppc").getreceivedbyaddress(
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).getreceivedbyaddress(
                       'PHvDhfz1dGyPbZZ3Qnp56y92zmy98sncZT'), Decimal)
 
 
 def test_explorer_listunspent():
 
-    assert isinstance(Explorer(network="ppc").listunspent(
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).listunspent(
                       'PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw'), list)
 
 
 def test_explorer_getrawtransaction():
 
-    assert isinstance(Explorer(network="ppc").getrawtransaction(
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).getrawtransaction(
                       '34d19bf5a5c757d5bcbf83a91ad9bc04365c58a035a6bf728bce8013ad04c173'), dict)
 
 
 def test_explorer_listtransactions():
 
-    assert isinstance(Explorer(network="ppc").listtransactions(
+    assert isinstance(Explorer(NETWORKS["peercoin"]()).listtransactions(
                       'PHvDhfz1dGyPbZZ3Qnp56y92zmy98sncZT'), list)

--- a/test/test_provider_holytransaction.py
+++ b/test/test_provider_holytransaction.py
@@ -1,21 +1,22 @@
 import pytest
 
+from pypeerassets.networks import NETWORKS
 from pypeerassets.provider.holytransaction import Holy
 
 
 def test_holy_is_testnet():
 
-    assert Holy(network="peercoin-testnet").is_testnet is True
+    assert Holy(NETWORKS["peercoin-testnet"]()).network.is_testnet is True
 
 
 def test_holy_network():
 
-    assert Holy(network="ppc").network == "peercoin"
+    assert Holy(NETWORKS["peercoin"]()).network.name == "peercoin"
 
 
 def test_holy_getdifficulty():
 
-    get_diff = Holy(network="peercoin").getdifficulty()
+    get_diff = Holy(NETWORKS["peercoin"]()).getdifficulty()
 
     assert isinstance(get_diff, dict)
     assert sorted(get_diff.keys()) == ['proof-of-stake', 'proof-of-work', 'search-interval']
@@ -23,12 +24,12 @@ def test_holy_getdifficulty():
 
 def test_holy_getblockcount():
 
-    assert isinstance(Holy(network="peercoin").getblockcount(), int)
+    assert isinstance(Holy(NETWORKS["peercoin"]()).getblockcount(), int)
 
 
 def test_holy_getblockhash():
 
-    get_blockhash = Holy(network="peercoin").getblockhash(313639)
+    get_blockhash = Holy(NETWORKS["peercoin"]()).getblockhash(313639)
 
     assert isinstance(get_blockhash, str)
     assert get_blockhash == 'be48bcf5155b4650d75d600bf1e9f37a5a049c2905542c6ced43ec0cb57673e8'
@@ -36,7 +37,7 @@ def test_holy_getblockhash():
 
 def test_holy_getblock():
 
-    getblock = Holy(network="peercoin").getblock("be48bcf5155b4650d75d600bf1e9f37a5a049c2905542c6ced43ec0cb57673e8")
+    getblock = Holy(NETWORKS["peercoin"]()).getblock("be48bcf5155b4650d75d600bf1e9f37a5a049c2905542c6ced43ec0cb57673e8")
 
     assert isinstance(getblock, dict)
     assert sorted(getblock.keys()) == ['bits', 'difficulty', 'entropybit',
@@ -52,7 +53,7 @@ def test_holy_getblock():
 @pytest.mark.parametrize("decrypt", [0, 1])
 def test_holy_getrawtransaction(decrypt):
 
-    getrawtransaction = Holy(network="peercoin").getrawtransaction('e4c8ebffe416836faa8f35ae9bc630cc2ac706faebc4e40d5556a755024a3689', decrypt)
+    getrawtransaction = Holy(NETWORKS["peercoin"]()).getrawtransaction('e4c8ebffe416836faa8f35ae9bc630cc2ac706faebc4e40d5556a755024a3689', decrypt)
 
     if decrypt:
         assert isinstance(getrawtransaction, dict)
@@ -72,7 +73,7 @@ def test_holy_getrawtransaction(decrypt):
 
 def test_holy_getaddress():
 
-    getaddress = Holy(network="peercoin").getaddress('PXBf64T4gqKcn7Kruw75X8V5yeci34HG92')
+    getaddress = Holy(NETWORKS["peercoin"]()).getaddress('PXBf64T4gqKcn7Kruw75X8V5yeci34HG92')
 
     assert isinstance(getaddress, dict)
     assert sorted(getaddress.keys()) == ['address', 'balance', 'last_txs', 'received', 'sent']
@@ -80,9 +81,9 @@ def test_holy_getaddress():
 
 def test_holy_getbalance():
 
-    assert isinstance(Holy(network="peercoin").getbalance('PXBf64T4gqKcn7Kruw75X8V5yeci34HG92'), float)
+    assert isinstance(Holy(NETWORKS["peercoin"]()).getbalance('PXBf64T4gqKcn7Kruw75X8V5yeci34HG92'), float)
 
 
 def test_holy_listtransactions():
 
-    assert isinstance(Holy(network="peercoin").listtransactions("PXBf64T4gqKcn7Kruw75X8V5yeci34HG92"), list)
+    assert isinstance(Holy(NETWORKS["peercoin"]()).listtransactions("PXBf64T4gqKcn7Kruw75X8V5yeci34HG92"), list)

--- a/test/test_provider_mintr.py
+++ b/test/test_provider_mintr.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pypeerassets.exceptions import UnsupportedNetwork
+from pypeerassets.networks import NETWORKS
 from pypeerassets.provider.mintr import Mintr
 
 
@@ -8,35 +9,35 @@ def test_mintr_only_supports_peercoin_mainnet():
 	"""Mintr only supports the peercoin mainnet and will throw an
 	UnsupportedNetwork exception if configured for another network.
 	"""
-	Mintr(network="peercoin")
+	Mintr(NETWORKS["peercoin"]())
 
 	with pytest.raises(UnsupportedNetwork):
-		Mintr(network="tppc")
+		Mintr(NETWORKS["peercoin-testnet"]())
 
 	with pytest.raises(UnsupportedNetwork):
-		Mintr(network="bitcoin")
+		Mintr(NETWORKS["bitcoin"]())
 
 
 def test_mintr_getinfo():
 
-    assert Mintr().getinfo() == {"testnet": False}
+    assert Mintr(NETWORKS["peercoin"]()).getinfo() == {"testnet": False}
 
 
 def test_mintr_network():
 
-    assert Mintr().network == "peercoin"
+    assert Mintr(NETWORKS["peercoin"]()).network.name == "peercoin"
 
 
 def test_mintr_getrawtransaction():
 
-    assert isinstance(Mintr().getrawtransaction("147c4daf47293fb670efd97dd7f9f6e964f515e6478e0cc3a668e4330f12ad6f"), dict)
+    assert isinstance(Mintr(NETWORKS["peercoin"]()).getrawtransaction("147c4daf47293fb670efd97dd7f9f6e964f515e6478e0cc3a668e4330f12ad6f"), dict)
 
 
 def test_mintr_getblock():
 
-    assert isinstance(Mintr().getblock('be48bcf5155b4650d75d600bf1e9f37a5a049c2905542c6ced43ec0cb57673e8'), dict)
+    assert isinstance(Mintr(NETWORKS["peercoin"]()).getblock('be48bcf5155b4650d75d600bf1e9f37a5a049c2905542c6ced43ec0cb57673e8'), dict)
 
 
 def test_mintr_listtransaction():
 
-    assert isinstance(Mintr().listtransactions("PPchatrw5hV1y3JUU2kxyL4LQccprbp8FX"), list)
+    assert isinstance(Mintr(NETWORKS["peercoin"]()).listtransactions("PPchatrw5hV1y3JUU2kxyL4LQccprbp8FX"), list)


### PR DESCRIPTION
@peerchemist @saeveritt 

This started out with me staring at `Provider` and trying to think of a way to add `validateaddress` without hard coding logic specific to Peercoin. After a few false starts I tried upgrading the `NetworkParams` tuples to classes and compose them with Providers (i.e. a Provider requires a Network to instantiate) to answer "network questions" like "is this address hash valid?" and "is this a testnet?".

Good news: I think the Network classes simplified some of the logic and functionality in the Providers and give us a model for being more "Blockchain Agnostic" as we move forward.

Bad news: It's a lot of change from someone that's only been working on this for two days :p Our test suite is still pretty beat-up so it's also difficult to say how many things broke from my changes.

Worse news: btcpy's Address.is_valid() doesn't appear to work... so I guess I'll go look at our fork of that project next :\

But overall, I think it might be a good direction. Lemme know what you think when you have a chance :rainbow: