### PR TITLE
Issue#27 remove holy and requests

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ X-Python-Version: >= 3.4
 Package: python3-pypeerassets
 Architecture: all
 Section: python
-Depends: python-requests (>= 2.4.3-1), python3-secp256k1, python3-peercoinrpc, python3-protobuf, ${misc:Depends}, ${python3:Depends}
+Depends: python3-secp256k1, python3-peercoinrpc, python3-protobuf, ${misc:Depends}, ${python3:Depends}
 Description: Python library to communicate with peercoin daemon via JSON-RPC protocol.
   Python Library to communicate with peercoin daemon via JSON-RPC protocol implemented with popular python-requests library.
  .

--- a/pypeerassets/__main__.py
+++ b/pypeerassets/__main__.py
@@ -108,7 +108,7 @@ def _increase_fee_and_sign(provider: Provider, key: Kutil, change_sum: Decimal,
     return signed
 
 
-def find_deck(provider: Provider, key: str, version: int, prod=True) -> list:
+def find_deck(provider: Provider, key: str, version: int, prod=True) -> Deck:
     '''Find specific deck by deck id.'''
 
     pa_params = param_query(provider.network)

--- a/pypeerassets/pautils.py
+++ b/pypeerassets/pautils.py
@@ -62,7 +62,7 @@ def find_deck_spawns(provider, prod=True):
         else:
             raise NotImplementedError
 
-    if isinstance(provider, Holy) or isinstance(provider, Cryptoid):
+    if isinstance(provider, Cryptoid):
 
         if prod:
             decks = (i for i in provider.listtransactions(pa_params.P2TH_addr))


### PR DESCRIPTION
@peerchemist @saeveritt 

A few good tibits in this one:

* Removed `Holy` provider since their website is having issues.
* Replaced `Holy` with `Explorer` in `test_pautils.py` and fixed a couple of the easier broken tests.
* Removed all references to `requests` (we can close out an issue! yey!) :rainbow: