### PR TITLE
Provider gets method validateaddress.

### DIFF
--- a/pypeerassets/provider/common.py
+++ b/pypeerassets/provider/common.py
@@ -1,11 +1,14 @@
 '''Common provider class with basic features.'''
 
 from abc import ABC, abstractmethod
+from decimal import Decimal
+import urllib.request
+
+from btcpy.structs.address import Address
+
 from pypeerassets.exceptions import UnsupportedNetwork
 from pypeerassets.pa_constants import PAParams, param_query
 from pypeerassets.networks import NetworkParams, net_query
-from decimal import Decimal
-import urllib.request
 
 
 class Provider(ABC):
@@ -107,3 +110,16 @@ class Provider(ABC):
     @abstractmethod
     def listtransactions(self, address: str) -> list:
         raise NotImplementedError
+
+    def validateaddress(self, address: str) -> bool:
+        """Returns True if the passed address is valid, False otherwise. Note
+        the limitation that we don't check the address against the underlying
+        network (i.e. strict=False). When btcpy can support multiple networks at
+        runtime we can be more precise (i.e. strict=True) ;)
+        """
+        try:
+            Address.from_string(address, strict=False)
+        except ValueError:
+            return False
+
+        return True

--- a/test/test_provider.py
+++ b/test/test_provider.py
@@ -1,0 +1,45 @@
+import pytest
+
+from pypeerassets.provider import (
+    Cryptoid,
+    Explorer,
+    Mintr,
+)
+
+
+@pytest.mark.parametrize("provider_cls", [Cryptoid, Explorer, Mintr,])
+def test_validateaddress_peercoin(provider_cls):
+    "Check Providers that can validate Peercoin addresses."
+
+    provider = provider_cls(network='peercoin')
+
+    # Peercoin P2PKH, P2SH addresses.
+    assert provider.validateaddress("PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw") is True
+    assert provider.validateaddress("p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK") is True
+
+    # Peercoin Testnet P2PKH address (these _should_ be False, but btcpy cannot
+    # support it at the moment).
+    assert provider.validateaddress("mj46gUeZgeD9ufU7Fvz2dWqaX6Nswtbpba") is True
+
+    # Very much not Peercoin addresses.
+    assert provider.validateaddress("1BFQfjM29kubskmaAsPjPCfHYphYvKA7Pj") is False
+    assert provider.validateaddress("2NFNPUYRpDXf3YXEuVT6AdMesX4kyeyDjtp") is False
+
+
+@pytest.mark.parametrize("provider_cls", [Cryptoid, Explorer,])
+def test_validateaddress_peercoin_testnet(provider_cls):
+    "Check Providers that can validate Peercoin Testnet addresses."
+
+    provider = provider_cls(network='peercoin-testnet')
+
+    # Peercoin Testnet P2PKH address.
+    assert provider.validateaddress("mj46gUeZgeD9ufU7Fvz2dWqaX6Nswtbpba") is True
+
+    # Peercoin P2PKH, P2SH addresses (these _should_ be False, but btcpy cannot
+    # support it at the moment).
+    assert provider.validateaddress("PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw") is True
+    assert provider.validateaddress("p92W3t7YkKfQEPDb7cG9jQ6iMh7cpKLvwK") is True
+
+    # Very much not Peercoin Testnet addresses.
+    assert provider.validateaddress("1BFQfjM29kubskmaAsPjPCfHYphYvKA7Pj") is False
+    assert provider.validateaddress("2NFNPUYRpDXf3YXEuVT6AdMesX4kyeyDjtp") is False


### PR DESCRIPTION
@peerchemist @saeveritt 

This is for #70 :) It works for now but it would be really nice to have the "ALLPY" version of "btcpy" so we can start using the `strict` mode *and* eventually support other blockchain networks :rainbow: 