### PR TITLE
Install peercoin_rpc during dev to run tests.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 mypy
+peercoin_rpc>=0.56
 pytest


### PR DESCRIPTION
@peerchemist 

This should let the unit tests run while still keeping the the dependency out of the main package requirements :rainbow: :fountain: :four_leaf_clover: :horse_racing: 

Our travis ci build button can go back to being green and happy :)