### PR TITLE
Use COVERALLS_PARALLEL=true for coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
 script:
   - pytest --cov=pypeerassets
 after_success:
-  - coveralls
+  - COVERALLS_PARALLEL=true coveralls


### PR DESCRIPTION
I noticed a couple of strange "duplicate files" in the coveralls reports. I'm guessing it could be caused by Travis CI running two jobs (one for testing python 3.5 and one for 3.6) and us not telling coveralls that we want it to merge the output from these runs together.

https://coveralls-python.readthedocs.io/en/latest/usage/configuration.html?highlight=parallel

Any way, perhaps one small setting change and we can see if the problem goes away :)