### PR TITLE
Constants move from btcpy to pypeerassets

### DIFF
--- a/pypeerassets/kutil.py
+++ b/pypeerassets/kutil.py
@@ -25,7 +25,7 @@ class Kutil:
            '''
 
         self.network = network
-        self.btcpy_constants = net_query(self.network).btcpy_constants
+        self.constants = net_query(self.network)
 
         if privkey is not None:
             self._private_key = PrivateKey(privkey)
@@ -36,7 +36,7 @@ class Kutil:
 
         if from_wif is not None:
             self._private_key = PrivateKey.from_wif(wif=from_wif,
-                                                    network=self.btcpy_constants,
+                                                    network=self.constants,
                                                     )
 
         if not privkey:
@@ -50,14 +50,16 @@ class Kutil:
     @property
     def address(self) -> str:
         '''generate an address from pubkey'''
-        btcpy_constants = net_query(self.network).btcpy_constants
-        return str(self._public_key.to_address(btcpy_constants))
+
+        return str(self._public_key.to_address(
+                   net_query(self.network))
+                   )
 
     @property
     def wif(self) -> str:
         '''convert raw private key to WIF'''
 
-        return self._private_key.to_wif(network=self.btcpy_constants)
+        return self._private_key.to_wif(network=self.constants)
 
     def sign_transaction(self, txins: Union[TxOut],
                          tx: MutableTransaction) -> MutableTransaction:

--- a/pypeerassets/networks.py
+++ b/pypeerassets/networks.py
@@ -1,30 +1,24 @@
 from collections import namedtuple
 from decimal import Decimal
-
-from btcpy.constants import (
-  BitcoinMainnet,
-  BitcoinTestnet,
-  PeercoinMainnet,
-  PeercoinTestnet,
-)
-
 from pypeerassets.exceptions import UnsupportedNetwork
 
-
-NetworkParams = namedtuple('NetworkParams', [
-    'network_name',
-    'network_shortname',
-    'pubkeyhash',
+# constants to be consumed by the backend
+Constants = namedtuple('Constants', [
+    'name',
+    'shortname',
+    'base58_prefixes',
+    'base58_raw_prefixes',
+    'bech32_hrp',
+    'bech32_net',
+    'xkeys_prefix',
+    'xpub_version',
+    'xprv_version',
     'wif_prefix',
-    'scripthash',
-    'magicbytes',
-    'msgPrefix',
+    'from_unit',
+    'to_unit',
     'min_tx_fee',
-    'min_vout_value',
     'tx_timestamp',
-    'denomination',
-    'op_return_max_bytes',
-    'btcpy_constants',
+    'op_return_max_bytes'
 ])
 
 
@@ -34,36 +28,66 @@ For abbreviation prefix testnet of the network with "t".
 '''
 
 networks = (
+
     # Peercoin mainnet
-    NetworkParams("peercoin", "ppc", b'37', b'b7', b'75', b'e6e8e9e5',
-                  b'\x17PPCoin Signed Message:\n', Decimal(0.01),
-                  0, True, Decimal('1e6'), 80,
-                  PeercoinMainnet),
+    Constants(
+        name='peercoin',
+        shortname='ppc',
+        base58_prefixes={
+            'P': 'p2pkh',
+            'p': 'p2sh',
+        },
+        base58_raw_prefixes={
+            'p2pkh': bytearray(b'\x37'),
+            'p2sh': bytearray(b'\x75'),
+        },
+        bech32_hrp='bc',
+        bech32_net='mainnet',
+        xkeys_prefix='x',
+        xpub_version=b'\x04\x88\xb2\x1e',
+        xprv_version=b'\x04\x88\xad\xe4',
+        wif_prefix=0xb7,
+        from_unit=Decimal('1e-6'),
+        to_unit=Decimal('1e6'),
+        min_tx_fee=Decimal(0.01),
+        tx_timestamp=True,
+        op_return_max_bytes=80
+    ),
+
     # Peercoin testnet
-    NetworkParams("peercoin-testnet", "tppc", b'6f', b'ef', b'c4', b'cbf2c0ef',
-                  b'\x17PPCoin Signed Message:\n', Decimal(0.01),
-                  0, True, Decimal('1e6'), 80,
-                  PeercoinTestnet),
-    # Bitcoin mainnet
-    NetworkParams("bitcoin", "btc", b'00', b'80', b'05', b'd9b4bef9',
-                  b'\x18Bitcoin Signed Message:\n', 0, 0, False,
-                  Decimal('1e8'), 80,
-                  BitcoinMainnet),
-    # Bitcoin testnet
-    NetworkParams("bitcoin-testnet", "tbtc", b'6f', b'ef', b'c4', b'dab5bffa',
-                  b'\x18Bitcoin Signed Message:\n', 0, 0, False,
-                  Decimal('1e8'), 80,
-                  BitcoinTestnet)
+    Constants(
+        name='peercoin-testnet',
+        shortname='tppc',
+        base58_prefixes={
+            'm': 'p2pkh',
+            'n': 'p2pkh',
+        },
+        base58_raw_prefixes={
+            'p2pkh': bytearray(b'\x6f'),
+            'p2sh': bytearray(b'\xc4'),
+        },
+        bech32_hrp='tb',
+        bech32_net='testnet',
+        xkeys_prefix='t',
+        xpub_version=b'\x04\x35\x87\xcf',
+        xprv_version=b'\x04\x35\x83\x94',
+        wif_prefix=0xef,
+        from_unit=Decimal('1e-6'),
+        to_unit=Decimal('1e6'),
+        min_tx_fee=Decimal(0.01),
+        tx_timestamp=True,
+        op_return_max_bytes=80
+    )
 )
 
 
-def net_query(name: str) -> NetworkParams:
+def net_query(name: str) -> Constants:
     '''Find the NetworkParams for a network by its long or short name. Raises
     UnsupportedNetwork if no NetworkParams is found.
     '''
 
     for net_params in networks:
-        if name in (net_params.network_name, net_params.network_shortname,):
+        if name in (net_params.name, net_params.shortname,):
             return net_params
 
     raise UnsupportedNetwork

--- a/pypeerassets/provider/common.py
+++ b/pypeerassets/provider/common.py
@@ -8,7 +8,7 @@ from btcpy.structs.address import Address
 
 from pypeerassets.exceptions import UnsupportedNetwork
 from pypeerassets.pa_constants import PAParams, param_query
-from pypeerassets.networks import NetworkParams, net_query
+from pypeerassets.networks import Constants, net_query
 
 
 class Provider(ABC):
@@ -23,8 +23,8 @@ class Provider(ABC):
         required because some providers use shortnames and other use longnames.'''
 
         try:
-            long = net_query(name).network_name
-            short = net_query(name).network_shortname
+            long = net_query(name).name
+            short = net_query(name).shortname
         except AttributeError:
             raise UnsupportedNetwork('''This blockchain network is not supported by the pypeerassets, check networks.py for list of supported networks.''')
 
@@ -44,7 +44,7 @@ class Provider(ABC):
         return param_query(self.network)
 
     @property
-    def network_properties(self) -> NetworkParams:
+    def network_properties(self) -> Constants:
         '''network parameters [min_fee, denomination, ...]'''
 
         return net_query(self.network)
@@ -115,9 +115,9 @@ class Provider(ABC):
 
     def validateaddress(self, address: str) -> bool:
         "Returns True if the passed address is valid, False otherwise."
-        btcpy_constants = self.network_properties.btcpy_constants
+
         try:
-            Address.from_string(btcpy_constants, address)
+            Address.from_string(self.network_properties, address)
         except ValueError:
             return False
 

--- a/pypeerassets/transactions.py
+++ b/pypeerassets/transactions.py
@@ -45,7 +45,7 @@ def p2pkh_script(network: str, address: str) -> P2pkhScript:
 
     network_params = net_query(network)
 
-    addr = Address.from_string(network=network_params.btcpy_constants,
+    addr = Address.from_string(network=network_params,
                                string=address)
 
     return P2pkhScript(addr)
@@ -57,8 +57,8 @@ def tx_output(network: str, value: Decimal, n: int,
 
     network_params = net_query(network)
 
-    return TxOut(network=network_params.btcpy_constants,
-                 value=int(value * network_params.denomination),
+    return TxOut(network=network_params,
+                 value=int(value * network_params.to_unit),
                  n=n, script_pubkey=script)
 
 
@@ -74,14 +74,14 @@ def make_raw_transaction(
 
     network_params = net_query(network)
 
-    if network_params.network_name.startswith("peercoin"):
+    if network_params.name.startswith("peercoin"):
         return PeercoinMutableTx(
             version=version,
             timestamp=timestamp,
             ins=inputs,
             outs=outputs,
             locktime=locktime,
-            network=network_params.btcpy_constants,
+            network=network_params,
         )
 
     return MutableTransaction(
@@ -89,7 +89,7 @@ def make_raw_transaction(
         ins=inputs,
         outs=outputs,
         locktime=locktime,
-        network=network_params.btcpy_constants,
+        network=network_params,
     )
 
 
@@ -100,7 +100,7 @@ def find_parent_outputs(provider: Provider, utxo: TxIn) -> TxOut:
     index = utxo.txout  # utxo index
     return TxOut.from_json(provider.getrawtransaction(utxo.txid,
                            1)['vout'][index],
-                           network=network_params.btcpy_constants)
+                           network=network_params)
 
 
 def sign_transaction(provider: Provider, unsigned: MutableTransaction,

--- a/test/test_kutil.py
+++ b/test/test_kutil.py
@@ -81,7 +81,7 @@ def test_sign_transaction():
                                  timestamp=int(time.time()),
                                  ins=unspent['utxos'],
                                  outs=[output],
-                                 network=network_params.btcpy_constants,
+                                 network=network_params,
                                  locktime=Locktime(0)
                                  )
 

--- a/test/test_networks.py
+++ b/test/test_networks.py
@@ -9,12 +9,12 @@ def test_net_query():
 
     # Use a network's long name
     net_params = net_query("peercoin")
-    assert net_params.network_shortname == "ppc"
+    assert net_params.shortname == "ppc"
 
     # Use a network's short name
-    net_params = net_query("tbtc")
-    assert net_params.network_name == "bitcoin-testnet"
+    net_params = net_query("tppc")
+    assert net_params.name == "peercoin-testnet"
 
     # Try to find a network we don't know about.
     with pytest.raises(UnsupportedNetwork):
-        net_query("not a network name we know")
+        net_query("not a network name we know of.")

--- a/test/test_protocol.py
+++ b/test/test_protocol.py
@@ -53,7 +53,7 @@ def test_oversize_deck_object():
             name="oversize_super_mega_deck_1119",
             number_of_decimals=18,
             issue_mode=IssueMode.SUBSCRIPTION.value,
-            network="btc",
+            network="ppc",
             production=True,
             version=1,
             asset_specific_data="""

--- a/test/test_transactions.py
+++ b/test/test_transactions.py
@@ -32,13 +32,11 @@ def test_calculate_transaction_fee(tx_size):
     assert round(calculate_tx_fee(tx_size), 2) == round(Decimal(0.01), 2)
 
 
-@pytest.mark.parametrize("network", ['bitcoin', 'peercoin'])
+@pytest.mark.parametrize("network", ['peercoin'])
 def test_tx_output(network):
 
     if network == 'peercoin':
         addr = 'PAdonateFczhZuKLkKHozrcyMJW7Y6TKvw'
-    if network == 'bitcoin':
-        addr = '1FV9w4NvBnnNp4GMUNuqfzqGKvgBY5YTSB'
 
     script = p2pkh_script(network, addr)
 
@@ -60,16 +58,13 @@ def test_nulldata_script():
 
 def test_p2pkh_script():
 
-    addr = '1FV9w4NvBnnNp4GMUNuqfzqGKvgBY5YTSB'
-    script = p2pkh_script('bitcoin', addr)
+    addr = 'mvWDumZZZVD2nEC7hmsX8dMSHoGHAq5b6d'
+    script = p2pkh_script('tppc', addr)
 
     assert isinstance(script, P2pkhScript)
 
 
 def test_make_raw_transaction():
-
-    tx = make_raw_transaction("bitcoin", [], [], Locktime(0))
-    assert isinstance(tx, MutableTransaction)
 
     tx = make_raw_transaction("peercoin", [], [], Locktime(300000))
     assert isinstance(tx, MutableTransaction)
@@ -97,7 +92,7 @@ def test_sign_transaction():
                                  ins=unspent['utxos'],
                                  outs=[output],
                                  locktime=Locktime(0),
-                                 network=network_params.btcpy_constants
+                                 network=network_params
                                  )
 
     assert isinstance(sign_transaction(provider, unsigned, key), Transaction)


### PR DESCRIPTION
This removes the need for our custom constants in the btcpy fork. Hopefully another stop toward deprecating our btcpy fork.